### PR TITLE
Proper paths

### DIFF
--- a/config.md
+++ b/config.md
@@ -11,6 +11,8 @@ The website_* must be defined for the RSS to work
 
 @def mintoclevel = 2
 
+@def prepath = "emat30008"
+
 <!--
 Add here files or directories that should be ignored by Franklin, otherwise
 these files might be copied and, if markdown, processed by Franklin which


### PR DESCRIPTION
this `prepath` page variable helps indicate that the base URL for the site is not `engmaths.github.io` but `engmaths.github.io/$prepath/` 